### PR TITLE
new entries in config for shortest_path caching

### DIFF
--- a/configs/default.cfg
+++ b/configs/default.cfg
@@ -54,7 +54,7 @@ cache_file: %(FOURLANGPATH)s/data/hunmorph_cache.txt
 
 [similarity_machine_longman]
 type: machine
-sim_types: 0-connected|is_antonym|fullgraph
+sim_types: 0-connected|is_antonym
 4langpath: %(FOURLANGPATH)s
 definitions_binary: %(4langpath)s/data/machines/longman_firsts.pickle
 graph_dir: %(4langpath)s/data/graphs/sts_longman
@@ -88,16 +88,16 @@ simlex: SimLex-999.txt
 
 [embeddings]
 enable_4lang: false
-#4lang_model: longman
-#word2vec: GoogleNews-vectors-negative300.bin
-#sympat: sp_plus_embeddings_500.w2v
-#glove: glove.840B.300d.w2v
-#huang: combined.txt
-#senna: combined.txt
-#paragram_300: paragram_300_sl999.txt
+4lang_model: longman
+word2vec: GoogleNews-vectors-negative300.bin
+sympat: sp_plus_embeddings_500.w2v
+glove: glove.840B.300d.w2v
+huang: combined.txt
+senna: combined.txt
+paragram_300: paragram_300_sl999.txt
 
 [wordnet]
-enabled: false
+enabled: true
 
 [machines]
 longman: longman


### PR DESCRIPTION
In the config file in section [similarity_machine_longman] there are two new entries:

shortest_path_res: %(4langpath)s/data/paths/dijstra_res.txt
calc_shortest_path: false

The first entry is the path to the file to where the cache data of the calculated shortest paths should be saved, and at the same time it corresponds to the file from where the cached data should be read out in case the calc_shortest_path flag is set to true or the path itself does not exist.
